### PR TITLE
Allow connect with OAuth packages that doesn't use the standard naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .build*
+
+# IDE
+.idea

--- a/client.js
+++ b/client.js
@@ -36,6 +36,6 @@ Meteor.connectWith = function (service, options, callback) {
 		options = null;
 	}
 	var connectCredentialRequestCompleteCallback = Accounts.oauth.connectCredentialRequestCompleteHandler(callback);
-	var Service = Package[service][makePascalCased(service)];
+	var Service = typeof service === "string" ? Package[service][makePascalCased(service)] : service;
 	Service.requestCredential(options, connectCredentialRequestCompleteCallback);
 };


### PR DESCRIPTION
I'm trying to use with your module with [gcampax:accounts-dropbox](https://atmospherejs.com/gcampax/accounts-dropbox) which uses [gcampax:dropbox-oauth](https://atmospherejs.com/gcampax/dropbox-oauth) under the hood. I cannot use this with provided `connectWith` method, since there is no OAuth module to be found when I pass the name of the package as the argument, eg.:

``` js
Meteor.connectWith("gcampax:dropbox-oauth");
```

Your module's gonna look for Package["gcampax:dropbox-oauth"]["Gcampax:dropbox-oauth"] on this case and it doesn't exists of course.

So I propose a cheap fix for this in this PR. If connectWith argument is a string, then OAuth provider gets selected by your way, else the argument threated as the provider itself. So I can use your module with dropbox provider by entering:

``` js
Meteor.connectWith(Package["gcampax:dropbox-oauth"]["DropboxOAuth"]);
```

Small PR but huge benefit, ain't it?
